### PR TITLE
use appliance 0.2.16 and use full path for resource pool and folder

### DIFF
--- a/src/appliance-onboarding-script/appliance_setup/avs/avsarconboarder/retriever/vsphere/vsphere_details_retriever.py
+++ b/src/appliance-onboarding-script/appliance_setup/avs/avsarconboarder/retriever/vsphere/vsphere_details_retriever.py
@@ -4,11 +4,14 @@ from ...retriever._retriever import Retriever
 
 class VSphereDetails(Retriever):
     instance = None
-    _arc_rp = "arc-rp"
-    _arc_folder = "arc-folder"
+    _arc_rp_name = "arc-rp"
+    _arc_folder_name = "arc-folder"
     _data_center = "SDDC-Datacenter"
     _data_store = "vsanDatastore"
     _template_name = "arc-template"
+    _cluster_name = "Cluster-1"
+    _arc_rp = f"/{_data_center}/host/{_cluster_name}/Resources/{_arc_rp_name}"
+    _arc_folder = f"/{_data_center}/vm/{_arc_folder_name}"
 
     def __new__(cls):
         if cls.instance is None:

--- a/src/appliance-onboarding-script/run.ps1
+++ b/src/appliance-onboarding-script/run.ps1
@@ -21,7 +21,7 @@ $ProgressPreference = 'SilentlyContinue'
 
 # Use empty string for the version to fetch latest CLI version
 $AzExtensions=@{
-    "arcappliance"="0.2.11";
+    "arcappliance"="0.2.16";
     "connectedvmware"="0.1.6";
     "k8s-extension"="1.0.4";
     "customlocation"="0.1.3"};

--- a/src/appliance-onboarding-script/run.sh
+++ b/src/appliance-onboarding-script/run.sh
@@ -2,7 +2,7 @@
 
 # Use empty string for the version to fetch latest CLI version
 declare -A AzExtensions=(
-    ["arcappliance"]="0.2.11"
+    ["arcappliance"]="0.2.16"
     ["connectedvmware"]="0.1.6"
     ["k8s-extension"]="1.0.4"
     ["customlocation"]="0.1.3")


### PR DESCRIPTION
Update arc appliance version to 0.2.16. Arc appliance added support for specifying path for folder and resource pool, instead of just name. Consumed the change. This change helps supports scenarios where we want to use some folder, where there are other folders present with the same name. For instance, the using /folderA for arc onboarding when these folders exist [ /folderB/folderA , /folderA ]  was not supported earlier. Will be supported with the change. 
