### PR TITLE
Tusharjuneja/automated testing

### DIFF
--- a/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
+++ b/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
@@ -116,7 +116,7 @@ class ApplianceSetup(object):
         self._validate_appliance()
         self._prepare_appliance()
         appliance_id = self._deploy_and_create_appliance()
-        extension_id = self._create_or_delete_vmware_extension('create', self.default_vmware_sp_object_id)
+        extension_id = self._create_or_delete_vmware_extension('create', self._default_vmware_sp_object_id)
         if extension_id is not None:
             return self._arc_vmware_resources.create(appliance_id, extension_id)
 
@@ -161,7 +161,7 @@ class ApplianceSetup(object):
         except AzCommandError as e:
             logging.info(e)
         try:
-            self._create_or_delete_vmware_extension('delete', self.default_vmware_sp_object_id)
+            self._create_or_delete_vmware_extension('delete', self._default_vmware_sp_object_id)
         except AzCommandError as e:
             logging.info(e)
         self._delete_appliance()

--- a/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
+++ b/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
@@ -210,7 +210,7 @@ class ApplianceSetup(object):
             # Removing confirm_prompts for automated testing 
             # TODO Check what needs to be done in case there is a reachable ApiServer
             # For now, we consider the Api server to be correctly configured and don't deploy a new one.
-            if is_api_server_reachable and (self._isAutomated or not confirm_prompt(f'An ApiServer is already reachable on endpoint {apiserver_address}. Deployment will be skipped. Do you want to continue?')):
+            if (not self._isAutomated and (is_api_server_reachable and not confirm_prompt(f'An ApiServer is already reachable on endpoint {apiserver_address}. Deployment will be skipped. Do you want to continue?'))):
                 raise ProgramExit('User chose to exit the program.')
             if not is_api_server_reachable:
                 logging.info('Deploying appliance...')

--- a/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
+++ b/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
@@ -1,4 +1,5 @@
 import json, yaml, requests
+from xmlrpc.client import Boolean
 from tokenize import String
 from pathlib import Path
 import logging
@@ -88,14 +89,15 @@ class ApplianceSetup(object):
     _default_release_train = "stable"
     _vmware_rp_sp_id = "ac9dc5fe-b644-4832-9d03-d9f1ab70c5f7"
 
-    def __init__(self, config: dict, arc_vmware_resources: ArcVMwareResources, default_vmware_sp_object_id: String):
+    def __init__(self, config: dict, arc_vmware_resources: ArcVMwareResources, isAutomated: bool, input_vmware_sp_object_id: String):
         self._config = config
         self._local_appliance_yaml: str = self._temp_dir + '/vmware-appliance.yaml'
         self._local_resource_yaml: str = self._temp_dir + '/vmware-resource.yaml'
         self._local_infra_yaml: str = self._temp_dir + '/vmware-infra.yaml'
         self._local_vmware_extension: str = self._temp_dir + '/vmware-extension.json'
         self._arc_vmware_resources = arc_vmware_resources
-        self._default_vmware_sp_object_id = default_vmware_sp_object_id
+        self._isAutomated = isAutomated
+        self._input_vmware_sp_object_id = input_vmware_sp_object_id
 
     def _copy_proxy_cert_update_config(self):
         config = self._config
@@ -116,7 +118,7 @@ class ApplianceSetup(object):
         self._validate_appliance()
         self._prepare_appliance()
         appliance_id = self._deploy_and_create_appliance()
-        extension_id = self._create_or_delete_vmware_extension('create', self._default_vmware_sp_object_id)
+        extension_id = self._create_or_delete_vmware_extension('create')
         if extension_id is not None:
             return self._arc_vmware_resources.create(appliance_id, extension_id)
 
@@ -161,7 +163,7 @@ class ApplianceSetup(object):
         except AzCommandError as e:
             logging.info(e)
         try:
-            self._create_or_delete_vmware_extension('delete', self._default_vmware_sp_object_id)
+            self._create_or_delete_vmware_extension('delete')
         except AzCommandError as e:
             logging.info(e)
         self._delete_appliance()
@@ -208,16 +210,16 @@ class ApplianceSetup(object):
             # Removing confirm_prompts for automated testing 
             # TODO Check what needs to be done in case there is a reachable ApiServer
             # For now, we consider the Api server to be correctly configured and don't deploy a new one.
-            #if is_api_server_reachable and not confirm_prompt(f'An ApiServer is already reachable on endpoint {apiserver_address}. Deployment will be skipped. Do you want to continue?'):
-            #    raise ProgramExit('User chose to exit the program.')
+            if self._isAutomated or (is_api_server_reachable and not confirm_prompt(f'An ApiServer is already reachable on endpoint {apiserver_address}. Deployment will be skipped. Do you want to continue?')):
+                raise ProgramExit('User chose to exit the program.')
             if not is_api_server_reachable:
                 logging.info('Deploying appliance...')
                 res, err = az_cli('arcappliance', 'deploy', 'vmware',
                     '--config-file', 'vmware-appliance.yaml')
                 if err:
                     # Removing confirm_prompts for automated testing
-                    #if not confirm_prompt('Deployment failed. Still want to proceed?'):
-                    raise AzCommandError('arcappliance deploy command failed.')
+                    if self._isAutomated or not confirm_prompt('Deployment failed. Still want to proceed?'):
+                        raise AzCommandError('arcappliance deploy command failed.')
                 logging.info("arcappliance deploy command succeeded")
                 try:
                     copy('kubeconfig', '../')
@@ -262,7 +264,7 @@ class ApplianceSetup(object):
                 raise AzCommandError('arcappliance delete command failed.')
             logging.info("arcappliance delete command succeeded")
 
-    def _create_or_delete_vmware_extension(self, op='create', default_vmware_sp_object_id = None) -> str:
+    def _create_or_delete_vmware_extension(self, op='create') -> str:
         config = self._config
         if op not in ['create', 'delete']:
             raise InvalidOperation('Supported operations are \"create\" and \"delete\".')
@@ -281,7 +283,7 @@ class ApplianceSetup(object):
         except KeyError:
             pass
 
-        if default_vmware_sp_object_id is None:
+        if self._input_vmware_sp_object_id is None:
             vmware_rp_sp, err = az_cli('ad', 'sp', 'show', '--id', f'"{self._vmware_rp_sp_id}"')
             if err:
                 raise AzCommandError("Unable to get VMware SP object id.")
@@ -289,7 +291,7 @@ class ApplianceSetup(object):
             vmware_rp_sp = json.loads(vmware_rp_sp)
             vmware_rp_object_id = vmware_rp_sp["objectId"]
         else:
-            vmware_rp_object_id = default_vmware_sp_object_id
+            vmware_rp_object_id = self._input_vmware_sp_object_id
 
         res = None
         if op == 'create':

--- a/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
+++ b/src/appliance-onboarding-script/appliance_setup/pkgs/_appliance_setup.py
@@ -210,7 +210,7 @@ class ApplianceSetup(object):
             # Removing confirm_prompts for automated testing 
             # TODO Check what needs to be done in case there is a reachable ApiServer
             # For now, we consider the Api server to be correctly configured and don't deploy a new one.
-            if self._isAutomated or (is_api_server_reachable and not confirm_prompt(f'An ApiServer is already reachable on endpoint {apiserver_address}. Deployment will be skipped. Do you want to continue?')):
+            if is_api_server_reachable and (self._isAutomated or not confirm_prompt(f'An ApiServer is already reachable on endpoint {apiserver_address}. Deployment will be skipped. Do you want to continue?')):
                 raise ProgramExit('User chose to exit the program.')
             if not is_api_server_reachable:
                 logging.info('Deploying appliance...')
@@ -218,6 +218,7 @@ class ApplianceSetup(object):
                     '--config-file', 'vmware-appliance.yaml')
                 if err:
                     # Removing confirm_prompts for automated testing
+                    # Considering if deploy command fails, we fail the automation
                     if self._isAutomated or not confirm_prompt('Deployment failed. Still want to proceed?'):
                         raise AzCommandError('arcappliance deploy command failed.')
                 logging.info("arcappliance deploy command succeeded")

--- a/src/appliance-onboarding-script/appliance_setup/run.py
+++ b/src/appliance-onboarding-script/appliance_setup/run.py
@@ -59,6 +59,11 @@ if __name__ == "__main__":
     except IndexError:
         log_level = "INFO"
 
+    try:
+        default_vmware_sp_object_id = sys.argv[4]
+    except IndexError:
+        default_vmware_sp_object_id = None
+    
     log_level_dict = {
         "DEBUG": logging.DEBUG,
         "INFO": logging.INFO,
@@ -115,7 +120,7 @@ if __name__ == "__main__":
                 dns_data = dns_helper.retrieve_dns_config(_customer_details.customer_resource, _customer_details.cloud_details)
                 config[Constant.DNS_SERVICE_IP] = [dns_data.server_details['properties']['dnsServiceIp']]
         arc_vmware_res = ArcVMwareResources(config)
-        appliance_setup = ApplianceSetup(config, arc_vmware_res)
+        appliance_setup = ApplianceSetup(config, arc_vmware_res, default_vmware_sp_object_id)
 
         env_setup = VMwareEnvSetup(config)
         env_setup.setup()
@@ -124,12 +129,13 @@ if __name__ == "__main__":
         if config["isAVS"] and config["register"]:
             register_with_private_cloud(_customer_details.customer_resource, vcenterId)
     elif operation == 'offboard':
-        if not confirm_prompt('Do you want to proceed with offboard operation?'):
-            raise ProgramExit('User chose to exit the program.')
+        # Removing confirm_prompts for automated testing
+        #if not confirm_prompt('Do you want to proceed with offboard operation?'):
+        #    raise ProgramExit('User chose to exit the program.')
         if config["isAVS"] and config["register"]:
             deregister_from_private_cloud(_customer_details.customer_resource)
         arc_vmware_res = ArcVMwareResources(config)
-        appliance_setup = ApplianceSetup(config, arc_vmware_res)
+        appliance_setup = ApplianceSetup(config, arc_vmware_res, default_vmware_sp_object_id)
         appliance_setup.delete()
     else:
         raise InvalidOperation(f"Invalid operation entered - {operation}")

--- a/src/appliance-onboarding-script/appliance_setup/run.py
+++ b/src/appliance-onboarding-script/appliance_setup/run.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             register_with_private_cloud(_customer_details.customer_resource, vcenterId)
     elif operation == 'offboard':
         # Removing confirm_prompts for automated testing
-        if (isAutomated == True) or not confirm_prompt('Do you want to proceed with offboard operation?'):
+        if (isAutomated == False) and not confirm_prompt('Do you want to proceed with offboard operation?'):
             raise ProgramExit('User chose to exit the program.')
         if config["isAVS"] and config["register"]:
             deregister_from_private_cloud(_customer_details.customer_resource)

--- a/src/appliance-onboarding-script/appliance_setup/run.py
+++ b/src/appliance-onboarding-script/appliance_setup/run.py
@@ -112,6 +112,9 @@ if __name__ == "__main__":
 
     try:
         input_vmware_sp_object_id = sys.argv[5] # Input VmWareSPObjectID is the SP Object ID. This is passed down to the for setting up logs for connected vmware team.
+        if(input_vmware_sp_object_id == ''): # This is required since shell script sends in an empty script for no param passed
+            input_vmware_sp_object_id = None
+
     except IndexError:
         input_vmware_sp_object_id = None
     

--- a/src/appliance-onboarding-script/run.ps1
+++ b/src/appliance-onboarding-script/run.ps1
@@ -2,7 +2,7 @@
 Param(
     [parameter(Mandatory=$true)][string]$Operation,
     [Parameter(Mandatory=$true)] [string] $FilePath,
-    [Parameter(Mandatory=$false)] [string] $LogLevel,
+    [Parameter(Mandatory=$false)] [string] $LogLevel = 'INFO',
     [Parameter(Mandatory=$false)] [bool] $isAutomated = $false, # isAutomated Parameter is set to true if it is an automation testing Run. 
                                                                 # In case this param is true, we use az login --identity, which logs in Azure VM's identity
                                                                 # and skips the confirm prompts.

--- a/src/appliance-onboarding-script/run.ps1
+++ b/src/appliance-onboarding-script/run.ps1
@@ -198,7 +198,14 @@ else
 $az_account_check_token = az account get-access-token
 if ($az_account_check_token -eq $null){
     setPathForAzCliCert -config $config
-    az login --identity
+    if ($PSBoundParameters.ContainsKey('VmWareSPObjectID'))
+	{
+        az login --identity
+	}
+    else
+	{
+        az login --use-device-code
+	}
 }
 
 

--- a/src/appliance-onboarding-script/run.ps1
+++ b/src/appliance-onboarding-script/run.ps1
@@ -3,7 +3,10 @@ Param(
     [parameter(Mandatory=$true)][string]$Operation,
     [Parameter(Mandatory=$true)] [string] $FilePath,
     [Parameter(Mandatory=$false)] [string] $LogLevel,
-    [Parameter(Mandatory=$false)] [string] $VmWareSPObjectID
+    [Parameter(Mandatory=$false)] [bool] $isAutomated = $false, # isAutomated Parameter is set to true if it is an automation testing Run. 
+                                                                # In case this param is true, we use az login --identity, which logs in Azure VM's identity
+                                                                # and skips the confirm prompts.
+    [Parameter(Mandatory=$false)] [string] $VmWareSPObjectID # VmWareSPObjectID is the SP Object ID. This is passed down to the for setting up logs for connected vmware team.
 )
 
 $majorVersion = $PSVersionTable.PSVersion.Major
@@ -198,7 +201,7 @@ else
 $az_account_check_token = az account get-access-token
 if ($az_account_check_token -eq $null){
     setPathForAzCliCert -config $config
-    if ($PSBoundParameters.ContainsKey('VmWareSPObjectID'))
+    if ($isAutomated)
 	{
         az login --identity
 	}
@@ -214,7 +217,7 @@ foreach($x in $AzExtensions.GetEnumerator())
     installAzExtension -name $x.Name -version $x.Value
 }
 
-py .\appliance_setup\run.py $Operation $FilePath $LogLevel $VmWareSPObjectID
+py .\appliance_setup\run.py $Operation $FilePath $LogLevel $isAutomated $VmWareSPObjectID
 $OperationExitCode = $LASTEXITCODE
 
 printOperationStatusMessage -Operation $Operation -OperationExitCode $OperationExitCode

--- a/src/appliance-onboarding-script/run.ps1
+++ b/src/appliance-onboarding-script/run.ps1
@@ -2,7 +2,8 @@
 Param(
     [parameter(Mandatory=$true)][string]$Operation,
     [Parameter(Mandatory=$true)] [string] $FilePath,
-    [Parameter(Mandatory=$false)] [string] $LogLevel
+    [Parameter(Mandatory=$false)] [string] $LogLevel,
+    [Parameter(Mandatory=$false)] [string] $VmWareSPObjectID
 )
 
 $majorVersion = $PSVersionTable.PSVersion.Major
@@ -154,7 +155,7 @@ catch
 {
     Write-Host "Installing python..."
     Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.8.8/python-3.8.8-amd64.exe" -OutFile ".temp/python-3.8.8-amd64.exe"
-    $p = Start-Process .\.temp\python-3.8.8-amd64.exe -Wait -PassThru -ArgumentList '/quiet InstallAllUsers=0 PrependPath=1 Include_test=0'
+    $p = Start-Process .\.temp\python-3.8.8-amd64.exe -Wait -PassThru -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1 Include_test=0'
     $exitCode = $p.ExitCode
     if($exitCode -ne 0)
     {
@@ -197,7 +198,7 @@ else
 $az_account_check_token = az account get-access-token
 if ($az_account_check_token -eq $null){
     setPathForAzCliCert -config $config
-    az login --use-device-code
+    az login --identity
 }
 
 
@@ -206,7 +207,7 @@ foreach($x in $AzExtensions.GetEnumerator())
     installAzExtension -name $x.Name -version $x.Value
 }
 
-py .\appliance_setup\run.py $Operation $FilePath $LogLevel
+py .\appliance_setup\run.py $Operation $FilePath $LogLevel $VmWareSPObjectID
 $OperationExitCode = $LASTEXITCODE
 
 printOperationStatusMessage -Operation $Operation -OperationExitCode $OperationExitCode

--- a/src/appliance-onboarding-script/run.sh
+++ b/src/appliance-onboarding-script/run.sh
@@ -129,7 +129,8 @@ python3.8 -m venv .temp/.env || fail
 activate_python_venv
 python -m pip install --upgrade pip || fail
 python -m pip install -r ./appliance_setup/dependencies || fail
-python ./appliance_setup/run.py "$1" "$2" "${3:-INFO}" "${4:-None}"
+# TODO: Add support for automation testing in Linux Scripts.
+python ./appliance_setup/run.py "$1" "$2" "${3:-INFO}" "${4:-false}" "${5:-None}" 
 operation_exit_code=$?
 print_operation_status_message $1 $operation_exit_code
 deactivate_python_venv

--- a/src/appliance-onboarding-script/run.sh
+++ b/src/appliance-onboarding-script/run.sh
@@ -109,7 +109,7 @@ then
   sudo -E chmod +x ./.temp/govc
 fi
 
-( ( az version || (curl -sL https://aka.ms/InstallAzureCLIDeb | sudo -E bash) ) && ( az account get-access-token || az login --identity ) ) || { echo 'az installation or login failed' ; fail; }
+( ( az version || (curl -sL https://aka.ms/InstallAzureCLIDeb | sudo -E bash) ) && ( az account get-access-token || az login --use-device-code ) ) || { echo 'az installation or login failed' ; fail; }
 
 for key in "${!AzExtensions[@]}"
 do

--- a/src/appliance-onboarding-script/run.sh
+++ b/src/appliance-onboarding-script/run.sh
@@ -109,7 +109,7 @@ then
   sudo -E chmod +x ./.temp/govc
 fi
 
-( ( az version || (curl -sL https://aka.ms/InstallAzureCLIDeb | sudo -E bash) ) && ( az account get-access-token || az login --use-device-code ) ) || { echo 'az installation or login failed' ; fail; }
+( ( az version || (curl -sL https://aka.ms/InstallAzureCLIDeb | sudo -E bash) ) && ( az account get-access-token || az login --identity ) ) || { echo 'az installation or login failed' ; fail; }
 
 for key in "${!AzExtensions[@]}"
 do
@@ -129,7 +129,7 @@ python3.8 -m venv .temp/.env || fail
 activate_python_venv
 python -m pip install --upgrade pip || fail
 python -m pip install -r ./appliance_setup/dependencies || fail
-python ./appliance_setup/run.py "$1" "$2" "${3:-INFO}"
+python ./appliance_setup/run.py "$1" "$2" "${3:-INFO}" "${4:-None}"
 operation_exit_code=$?
 print_operation_status_message $1 $operation_exit_code
 deactivate_python_venv

--- a/src/appliance-onboarding-script/run.sh
+++ b/src/appliance-onboarding-script/run.sh
@@ -130,7 +130,7 @@ activate_python_venv
 python -m pip install --upgrade pip || fail
 python -m pip install -r ./appliance_setup/dependencies || fail
 # TODO: Add support for automation testing in Linux Scripts.
-python ./appliance_setup/run.py "$1" "$2" "${3:-INFO}" "${4:-false}" "${5:-None}" 
+python ./appliance_setup/run.py "$1" "$2" "${3:-INFO}" "${4:-false}" "${5}" 
 operation_exit_code=$?
 print_operation_status_message $1 $operation_exit_code
 deactivate_python_venv


### PR DESCRIPTION
Introducing changes for supporting automated testing using Run-commands.
Major Changes:
1) Introduced a new command line parameter (isAutomated) - Basis this parameter, we check if the current run is automated. In case of automation run, we tweak certain behaviors like skipping confirm_prompts and logging in using az login --identity, which uses the MSI of the VM
2) Introduced a new command line parameter (VmWareSPObjectID) - If this parameter is present, we skip making the call "az ad sp show --id" which doesn't work with if the VM's Identity is used to make this call.
3) Removed the confirm_prompt's for isAutomated=true since these are interactive commands.
4) Python gets installed for all users since this way it gets installed for System user that runs the run command.

Note: The change only supports run command for Windows. In case Linux VM needs to have support, we will take it up independently.

Pre-req for Automated testing - 
The VM's system assigned identity should have access over the RG that has the AVS infra.