### PR TITLE
added dns server details in config for offboard experience

### DIFF
--- a/src/appliance_setup/run.py
+++ b/src/appliance_setup/run.py
@@ -148,6 +148,11 @@ if __name__ == "__main__":
         # TODO: Point to documentation link here for getting valid regions.
         if not validate_region(config[Constant.LOCATION]):
             raise InvalidRegion(f"This feature is only available in these regions: {Constant.VALID_LOCATIONS}")
+        
+        if config["isStatic"]:
+            dns_helper = DNSHelper()
+            dns_data = dns_helper.retrieve_dns_config(_customer_details.customer_resource, _customer_details.cloud_details)
+            config[Constant.DNS_SERVICE_IP] = [dns_data.server_details['properties']['dnsServiceIp']]
 
     if operation == 'onboard':
         if config["register"]:
@@ -168,11 +173,6 @@ if __name__ == "__main__":
                                                               None,
                                                               segment_data_converter.convert_data(config))
             nsx_orchestrator.orchestrate()
-            # TODO Move the DNS Helper out of the processor
-            if config["isStatic"]:
-                dns_helper = DNSHelper()
-                dns_data = dns_helper.retrieve_dns_config(_customer_details.customer_resource, _customer_details.cloud_details)
-                config[Constant.DNS_SERVICE_IP] = [dns_data.server_details['properties']['dnsServiceIp']]
         arc_vmware_res = ArcVMwareResources(config)
         appliance_setup = ApplianceSetup(config, arc_vmware_res, isAutomated)
 


### PR DESCRIPTION
The offboard experience was failing because of DNS server detials were not getting populated in yaml files given as input for arc appliance delete. arc appliance delete command needed dns server input also. Added dns server details in yaml files.