### PR TITLE
NSX Segment Name change Bug

### DIFF
--- a/src/appliance_setup/avs/avsarconboarder/processor/nsx/helper/_NSXSegmentHelper.py
+++ b/src/appliance_setup/avs/avsarconboarder/processor/nsx/helper/_NSXSegmentHelper.py
@@ -29,7 +29,7 @@ class NSXSegmentHelper:
     def _get_arc_segment_if_exists(self, result, segment_name):
         list_segment = result["value"]
         for segment in list_segment:
-            if segment["name"].casefold() == segment_name.casefold():
+            if segment["properties"]["displayName"].casefold() == segment_name.casefold():
                 return segment
         return None
     

--- a/src/appliance_setup/avs/avsarconboarder/utils/user_config_validatator.py
+++ b/src/appliance_setup/avs/avsarconboarder/utils/user_config_validatator.py
@@ -143,13 +143,13 @@ class ConfigValidator:
         segment_in_config = self.__config["staticIpNetworkDetails"]["networkForApplianceVM"]
         segment_cidr_in_config = self.__config["staticIpNetworkDetails"]["networkCIDRForApplianceVM"]
         for segment in res["value"]:
-            if segment["name"].casefold() == segment_in_config.casefold():
+            if segment["displayName"].casefold() == segment_in_config.casefold():
                 if segment["properties"]["subnet"]["gatewayAddress"] != segment_cidr_in_config:
                     raise InvalidInputError("Segment " + segment_in_config + " already exists with a different gateway ip cidr")
 
         for segment in res["value"]:
             if segment["properties"]["subnet"]["gatewayAddress"] == segment_cidr_in_config:
-                if segment["name"].casefold() != segment_in_config.casefold():
+                if segment["displayName"].casefold() != segment_in_config.casefold():
                     raise InvalidInputError("A different segment already present with gateway ip cidr " + segment_cidr_in_config)
      
     def validate_avs_config(self):

--- a/src/appliance_setup/avs/avsarconboarder/utils/user_config_validatator.py
+++ b/src/appliance_setup/avs/avsarconboarder/utils/user_config_validatator.py
@@ -143,13 +143,13 @@ class ConfigValidator:
         segment_in_config = self.__config["staticIpNetworkDetails"]["networkForApplianceVM"]
         segment_cidr_in_config = self.__config["staticIpNetworkDetails"]["networkCIDRForApplianceVM"]
         for segment in res["value"]:
-            if segment["displayName"].casefold() == segment_in_config.casefold():
+            if segment["properties"]["displayName"].casefold() == segment_in_config.casefold():
                 if segment["properties"]["subnet"]["gatewayAddress"] != segment_cidr_in_config:
                     raise InvalidInputError("Segment " + segment_in_config + " already exists with a different gateway ip cidr")
 
         for segment in res["value"]:
             if segment["properties"]["subnet"]["gatewayAddress"] == segment_cidr_in_config:
-                if segment["displayName"].casefold() != segment_in_config.casefold():
+                if segment["properties"]["displayName"].casefold() != segment_in_config.casefold():
                     raise InvalidInputError("A different segment already present with gateway ip cidr " + segment_cidr_in_config)
      
     def validate_avs_config(self):


### PR DESCRIPTION
The "Name" field in the response was being used to check if a segment exists/matches or not. 
"Name" is a field that doesn't change when a customer modifies name and doesn't change in the backend NSX and Azure. However "displayName" changes with modification and represents the correct state of segment name. Hence this change is to compare with "displayName" rather than "Name"

Repro:
1. customer creates a NSX segment with name "segment"
2. customer modifies the same segment to "segment-modified"
3. The "Name" field remains same as "segment" but "displayName" field changes to "segment-modified"

