### PR TITLE
Venkatjakka/customcred greenfield

### DIFF
--- a/src/appliance_setup/avs/_avs_orchestrator.py
+++ b/src/appliance_setup/avs/_avs_orchestrator.py
@@ -31,6 +31,12 @@ class AVSOrchestrator(Orchestrator):
         customer_res: CustomerResource = CustomerResource(config['resourceGroup'], config['subscriptionId'],
                                                           config['privateCloud'], appliance_name)
         customer_details: CustomerDetails = self.data_collector.collect_data(customer_res)
+        if(config["applianceCredentials"]):
+            if(config["applianceCredentials"]["username"].strip() != "" or
+               config["applianceCredentials"]["password"].strip() != ""):
+                logging.info("Custom Credentials are provided in config file")
+                customer_details.vcenter_credentials.username = config["applianceCredentials"]["username"]
+                customer_details.vcenter_credentials.password = config["applianceCredentials"]["password"]
         self.converter.convert_data(customer_details, config)
         return customer_details
 

--- a/src/appliance_setup/avs/_avs_orchestrator.py
+++ b/src/appliance_setup/avs/_avs_orchestrator.py
@@ -30,13 +30,7 @@ class AVSOrchestrator(Orchestrator):
             appliance_name = config['nameForApplianceInAzure']
         customer_res: CustomerResource = CustomerResource(config['resourceGroup'], config['subscriptionId'],
                                                           config['privateCloud'], appliance_name)
-        customer_details: CustomerDetails = self.data_collector.collect_data(customer_res)
-        if(config["applianceCredentials"]):
-            if(config["applianceCredentials"]["username"].strip() != "" or
-               config["applianceCredentials"]["password"].strip() != ""):
-                logging.info("Custom Credentials are provided in config file")
-                customer_details.vcenter_credentials.username = config["applianceCredentials"]["username"]
-                customer_details.vcenter_credentials.password = config["applianceCredentials"]["password"]
+        customer_details: CustomerDetails = self.data_collector.collect_data(customer_res, config)
         self.converter.convert_data(customer_details, config)
         return customer_details
 

--- a/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
+++ b/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
@@ -36,7 +36,7 @@ class DataCollector(Collector):
 
     def _collect_customer_credentials(self, customer_res, config):
         if(config["applianceCredentials"]):
-            if(config["applianceCredentials"]["username"].strip() != "" or
+            if(config["applianceCredentials"]["username"].strip() != "" and
                config["applianceCredentials"]["password"].strip() != ""):
                 logging.info(f"Custom Credentials are provided in config file. "
                              f"Using username: {config['applianceCredentials']['username']} for Onboarding Arc appliance.")

--- a/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
+++ b/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
@@ -42,11 +42,11 @@ class DataCollector(Collector):
                              f"Using username: {config['applianceCredentials']['username']}.")
                 customer_credentials = Credentials(username=config['applianceCredentials']['username'],
                                    password=config['applianceCredentials']['password'])
-        else:
-            logging.info("Custom Credentials are not provided in config file. "
-                     "Using cloudAdmin for vCenter.")
-            customer_credentials = self.credentials_retriever.retrieve_data(customer_res)
-
+                return customer_credentials
+            
+        logging.info("Custom Credentials are not provided in config file. "
+                    "Using cloudAdmin for vCenter.")
+        customer_credentials = self.credentials_retriever.retrieve_data(customer_res)
         return customer_credentials
         
     def _collect_customer_cloud_data(self, customer_res):

--- a/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
+++ b/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
@@ -1,7 +1,10 @@
+import logging
+
 from ..bundler.bundler import Bundler
 from ..bundler.customer_details_bundler import CustomerDetailsBundler
 from ..collector.collector import Collector
 from ..entity.CustomerResource import CustomerResource
+from ..entity._credentials import Credentials
 from ..factory import retriever
 from ..factory.retriever import retriever
 from ..retriever import _retriever
@@ -24,12 +27,28 @@ class DataCollector(Collector):
 
     def collect_data(self, *args):
         customer_res: CustomerResource = args[0]
-        cloud_details, customer_credentials = self._collect_customer_cloud_data(customer_res)
+        config = args[1]
+        cloud_details = self._collect_customer_cloud_data(customer_res)
+        customer_credentials = self._collect_customer_credentials(customer_res, config)
         vsphere_resource = self._vsphere_resource_retriever.retrieve_data(cloud_details, customer_credentials)
         return self.customer_details_bundler.bundle_data(customer_res, customer_credentials, cloud_details,
                                                          vsphere_resource)
 
+    def _collect_customer_credentials(self, customer_res, config):
+        if(config["applianceCredentials"]):
+            if(config["applianceCredentials"]["username"].strip() != "" or
+               config["applianceCredentials"]["password"].strip() != ""):
+                logging.info(f"Custom Credentials are provided in config file. "
+                             f"Using username: {config['applianceCredentials']['username']}.")
+                customer_credentials = Credentials(username=config['applianceCredentials']['username'],
+                                   password=config['applianceCredentials']['password'])
+        else:
+            logging.info("Custom Credentials are not provided in config file. "
+                     "Using cloudAdmin for vCenter.")
+            customer_credentials = self.credentials_retriever.retrieve_data(customer_res)
+
+        return customer_credentials
+        
     def _collect_customer_cloud_data(self, customer_res):
-        customer_credentials = self.credentials_retriever.retrieve_data(customer_res)
         cloud_details = self.cloud_details_retriever.retrieve_data(customer_res)
-        return cloud_details, customer_credentials
+        return cloud_details

--- a/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
+++ b/src/appliance_setup/avs/avsarconboarder/collector/_DataCollector.py
@@ -39,13 +39,13 @@ class DataCollector(Collector):
             if(config["applianceCredentials"]["username"].strip() != "" or
                config["applianceCredentials"]["password"].strip() != ""):
                 logging.info(f"Custom Credentials are provided in config file. "
-                             f"Using username: {config['applianceCredentials']['username']}.")
+                             f"Using username: {config['applianceCredentials']['username']} for Onboarding Arc appliance.")
                 customer_credentials = Credentials(username=config['applianceCredentials']['username'],
                                    password=config['applianceCredentials']['password'])
                 return customer_credentials
             
         logging.info("Custom Credentials are not provided in config file. "
-                    "Using cloudAdmin for vCenter.")
+                    "Using cloudadmin user account for Onboarding Arc appliance.")
         customer_credentials = self.credentials_retriever.retrieve_data(customer_res)
         return customer_credentials
         

--- a/src/config_avs.json
+++ b/src/config_avs.json
@@ -7,6 +7,10 @@
     "networkForApplianceVM": "",
     "networkCIDRForApplianceVM": ""
   },
+  "applianceCredentials": {
+    "username": "",
+    "password": ""
+  },
   "applianceProxyDetails": {
     "http": "",
     "https": "",

--- a/src/config_avs_old.json
+++ b/src/config_avs_old.json
@@ -3,12 +3,28 @@
   "resourceGroup": "",
   "applianceControlPlaneIpAddress": "",
   "privateCloud": "",
-    "isStatic": true,
-    "staticIpNetworkDetails": {
-      "networkForApplianceVM": "",
-      "networkCIDRForApplianceVM": "",
-      "k8sNodeIPPoolStart": "",
-      "k8sNodeIPPoolEnd": "",
-      "gatewayIPAddress": ""
-    }
+  "isStatic": true,
+  "staticIpNetworkDetails": {
+    "networkForApplianceVM": "",
+    "networkCIDRForApplianceVM": "",
+    "k8sNodeIPPoolStart": "",
+    "k8sNodeIPPoolEnd": "",
+    "gatewayIPAddress": ""
+  },
+  "applianceCredentials": {
+    "username": "",
+    "password": ""
+  },
+  "applianceProxyDetails": {
+    "http": "",
+    "https": "",
+    "noProxy": "",
+    "certificateFilePath": ""
+  },
+  "managementProxyDetails": {
+    "http": "",
+    "https": "",
+    "noProxy": "",
+    "certificateFilePath": ""
+  }
 }


### PR DESCRIPTION
## Problem
The Script was using CloudAdmin Credential by default for onboarding. When there is a rotation of password for this account, the ARB and Cluster Extension need to be rotated as well. Failure to rotate was resulting in Cloudadmin account lockout which is concerning to customer.

## Solution
Provided a field input in config_avs.json to provide a custom input of username and password for onboarding. The script will check for valid input in the JSON input and uses the custom credential. If there is no valid credential provided, the script will continue to onboard using CloudAdmin credential

## Testing
1. Successful Onboarding using Custom credentials
2. Successful Onboarding using CloudAdmin credentials when no input is provided
3. Failed attempt in case of Invalid credentials