### PR TITLE
Field check for status of Arc appliance

### DIFF
--- a/src/appliance_setup/pkgs/_azure_resource_validations.py
+++ b/src/appliance_setup/pkgs/_azure_resource_validations.py
@@ -16,7 +16,7 @@ def _wait_until_appliance_is_in_running_state(config: dict):
         )
         if not err:
             res = json.loads(res)
-            state = res['status']
+            state = res['properties']['status']
             logging.info(f'Appliance is in {state} state.')
             return state
         logging.error('Get appliance operation failed.')


### PR DESCRIPTION
The state field has changed from from res['status'] to res['properties']['status'] in the json response. Changed the response handling accordingly.