### PR TITLE
Adding more supported regions and README file

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,57 @@
+# Prerequisites
+To deploy Arc for Azure VMware Solution, you need to ensure the following prerequisites are met.
+
+For more information, please visit: https://learn.microsoft.com/en-us/azure/azure-vmware/deploy-arc-for-azure-vmware-solution
+
+## Providers
+The following Register features are for provider registration using Azure CLI.
+
+```bash
+az provider register --namespace Microsoft.ConnectedVMwarevSphere   
+az provider register --namespace Microsoft.ExtendedLocation  
+az provider register --namespace Microsoft.KubernetesConfiguration   
+az provider register --namespace Microsoft.ResourceConnector    
+az provider register --namespace Microsoft.AVS
+```
+
+## Networking
+From the management server you need to following ports open into the AVS Private Cloud:
+
+|Service|Port|Destination|Notes|
+|--------|----|----------|-----|
+|vCenter|443|vc.<id>.<region>.avs.azure.com|Used for the ArcOnAvs script|
+|ESXi Hosts|443|ESXi Segment|For example if our AVS network is 10.0.16.0/22 then 10.0.17.0/25|
+|AzureArc Resource Bridge|22,443,6443|AzureArc-Segment|The AzureArc segment created /28|
+
+# Configuration
+
+```json
+{
+  "subscriptionId": "",
+  "resourceGroup": "",
+  "privateCloud": "",
+  "isStatic": true,
+  "staticIpNetworkDetails": { 
+    "networkForApplianceVM": "", 
+    "networkCIDRForApplianceVM": ""
+  },
+  "applianceCredentials": { 
+    "username": "", 
+    "password": "" 
+  }, 
+  "applianceProxyDetails": { 
+    "http": "", 
+    "https": "", 
+    "noProxy": "", 
+    "certificateFilePath": "" 
+  }, 
+  "managementProxyDetails": { 
+    "http": "", 
+    "https": "", 
+    "noProxy": "", 
+    "certificateFilePath": "" 
+  }
+}
+```
+
+To use the cloudadmin credentials the values must be empty on the ```applianceCredentials```.

--- a/src/README.md
+++ b/src/README.md
@@ -55,3 +55,20 @@ From the management server you need to following ports open into the AVS Private
 ```
 
 To use the cloudadmin credentials the values must be empty on the ```applianceCredentials```.
+
+## Regions
+If your AVS region is not supported you can adjust the location as follow:
+
+|AVS Region|Recommended Region|Configuration|
+|----------|--------------------|-------------|
+|Switzerland North|West Europe|```"location": "westeurope"```|
+
+```json
+{
+  "subscriptionId": "",
+  "resourceGroup": "",
+  "privateCloud": "",
+  "location": "westeurope",
+  ...
+}
+```

--- a/src/appliance_setup/avs/avsarconboarder/constants/Constant.py
+++ b/src/appliance_setup/avs/avsarconboarder/constants/Constant.py
@@ -32,4 +32,4 @@ VNET_IP_CIDR = "VNET_IP_CIDR"
 DNS_SERVICE_IP = "DNS_Service_IP"
 CONFIG_VERSION_V1 = 0
 CONFIG_VERSION_V2 = 1
-VALID_LOCATIONS = "westeurope,eastus,australiaeast,canadacentral,uksouth,southeastasia,westus2,eastus2,northeurope,westus3,southcentralus,swedencentral,japaneast,eastasia,centralindia,northcentralus,ukwest,centralus,italynorth"
+VALID_LOCATIONS = "eastus,westeurope,uksouth,australiaeast,southeastasia,canadacentral,eastus2,westus2,westus3,southcentralus,northeurope,swedencentral,centralus,japaneast,eastasia,centralindia,ukwest,australiasoutheast,northcentralus,italynorth,germanywestcentral"


### PR DESCRIPTION
Included more supported regions and a README file to highlight the prerequisites, mainly on the networking side of things. In addition, the json configuration file must have the applianceCredentials empty to use the cloudadmin credentials.